### PR TITLE
feat: Implement shell for Settings page

### DIFF
--- a/front-end/src/components/SettingsAppearance.js
+++ b/front-end/src/components/SettingsAppearance.js
@@ -1,0 +1,15 @@
+import Card from "react-bootstrap/Card";
+
+const SettingsCard = (props) => {
+
+    return (
+        <>
+            <Card className="settings-card">
+                <Card.Title>Appearance</Card.Title>
+            </Card>
+        </>
+    )
+
+}
+
+export default SettingsCard;

--- a/front-end/src/components/SettingsPrivacy.js
+++ b/front-end/src/components/SettingsPrivacy.js
@@ -1,0 +1,15 @@
+import Card from "react-bootstrap/Card";
+
+const SettingsCard = (props) => {
+
+    return (
+        <>
+            <Card className="settings-card">
+                <Card.Title>Privacy</Card.Title>
+            </Card>
+        </>
+    )
+
+}
+
+export default SettingsCard;

--- a/front-end/src/components/SettingsProfile.js
+++ b/front-end/src/components/SettingsProfile.js
@@ -1,0 +1,15 @@
+import Card from "react-bootstrap/Card";
+
+const SettingsCard = (props) => {
+
+    return (
+        <>
+            <Card className="settings-card">
+                <Card.Title>Profile</Card.Title>
+            </Card>
+        </>
+    )
+
+}
+
+export default SettingsCard;

--- a/front-end/src/components/SettingsSecurity.js
+++ b/front-end/src/components/SettingsSecurity.js
@@ -1,0 +1,15 @@
+import Card from "react-bootstrap/Card";
+
+const SettingsCard = (props) => {
+
+    return (
+        <>
+            <Card className="settings-card">
+                <Card.Title>Security</Card.Title>
+            </Card>
+        </>
+    )
+
+}
+
+export default SettingsCard;

--- a/front-end/src/index.js
+++ b/front-end/src/index.js
@@ -5,6 +5,7 @@ import Home from "./pages/Home";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./index.css";
+import Settings from "./pages/Settings.js";
 
 export default function App() {
   return (
@@ -12,6 +13,9 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
+        </Route>
+        <Route path="/settings" element={<Layout />}>
+          <Route index element={<Settings />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/front-end/src/pages/Layout.js
+++ b/front-end/src/pages/Layout.js
@@ -36,6 +36,11 @@ const Layout = () => {
                 <Button className="main-nav-button">Friends</Button>
               </LinkContainer>
             </Nav.Item>
+            <Nav.Item>
+              <LinkContainer to="/settings">
+                <Button className="main-nav-button">Settings</Button>
+              </LinkContainer>
+            </Nav.Item>
           </Nav>
         </Container>
       </Navbar>

--- a/front-end/src/pages/Settings.css
+++ b/front-end/src/pages/Settings.css
@@ -4,7 +4,9 @@
     border-radius: 24px;
 }
 
-.settings-list .nav-link,  .settings-list .nav-link:hover, .settings-list .nav-link.active{
+.settings-list .nav-link,
+.settings-list .nav-link:hover,
+.settings-list .nav-link.active {
     font-size: 150%;
     background-color: transparent !important;
     border-color: transparent !important;
@@ -22,4 +24,8 @@
 
 .settings-list .nav-link.active {
     font-weight: bold;
+}
+
+.main-settings-container {
+    width: 75vw;
 }

--- a/front-end/src/pages/Settings.css
+++ b/front-end/src/pages/Settings.css
@@ -1,0 +1,25 @@
+.settings-card {
+    height: 100%;
+    padding: 1.5em;
+    border-radius: 24px;
+}
+
+.settings-list .nav-link,  .settings-list .nav-link:hover, .settings-list .nav-link.active{
+    font-size: 150%;
+    background-color: transparent !important;
+    border-color: transparent !important;
+    color: black !important;
+    text-align: left !important;
+}
+
+.settings-list .nav-link:hover {
+    opacity: 50%;
+}
+
+.settings-list .nav-link.active:hover {
+    opacity: 100% !important;
+}
+
+.settings-list .nav-link.active {
+    font-weight: bold;
+}

--- a/front-end/src/pages/Settings.js
+++ b/front-end/src/pages/Settings.js
@@ -11,46 +11,44 @@ import "../pages/Settings.css"
 
 const Settings = () => {
     return (
-        <div>
-            <Container>
-                <Tab.Container transition={false} defaultActiveKey="security">
-                    <Row>
-                        <Col>
-                            <Nav variant="pills" className="settings-list flex-column">
-                                <Nav.Item>
-                                    <Nav.Link eventKey="security">Security</Nav.Link>
-                                </Nav.Item>
-                                <Nav.Item>
-                                    <Nav.Link eventKey="profile">Profile</Nav.Link>
-                                </Nav.Item>
-                                <Nav.Item>
-                                    <Nav.Link eventKey="appearance">Appearance</Nav.Link>
-                                </Nav.Item>
-                                <Nav.Item>
-                                    <Nav.Link eventKey="privacy">Privacy</Nav.Link>
-                                </Nav.Item>
-                            </Nav>
-                        </Col>
-                        <Col sm={8}>
-                            <Tab.Content>
-                                <Tab.Pane eventKey="security">
-                                    <SettingsSecurity></SettingsSecurity>
-                                </Tab.Pane>
-                                <Tab.Pane eventKey="profile">
-                                    <SettingsProfile></SettingsProfile>
-                                </Tab.Pane>
-                                <Tab.Pane eventKey="appearance">
-                                    <SettingsAppearance></SettingsAppearance>
-                                </Tab.Pane>
-                                <Tab.Pane eventKey="privacy">
-                                    <SettingsPrivacy></SettingsPrivacy>
-                                </Tab.Pane>
-                            </Tab.Content>
-                        </Col>
-                    </Row>
-                </Tab.Container>
-            </Container>
-        </div>
+        <Container className="main-settings-container">
+            <Tab.Container transition={false} defaultActiveKey="security">
+                <Row>
+                    <Col>
+                        <Nav variant="pills" className="settings-list flex-column">
+                            <Nav.Item>
+                                <Nav.Link eventKey="security">Security</Nav.Link>
+                            </Nav.Item>
+                            <Nav.Item>
+                                <Nav.Link eventKey="profile">Profile</Nav.Link>
+                            </Nav.Item>
+                            <Nav.Item>
+                                <Nav.Link eventKey="appearance">Appearance</Nav.Link>
+                            </Nav.Item>
+                            <Nav.Item>
+                                <Nav.Link eventKey="privacy">Privacy</Nav.Link>
+                            </Nav.Item>
+                        </Nav>
+                    </Col>
+                    <Col sm={8}>
+                        <Tab.Content>
+                            <Tab.Pane eventKey="security">
+                                <SettingsSecurity></SettingsSecurity>
+                            </Tab.Pane>
+                            <Tab.Pane eventKey="profile">
+                                <SettingsProfile></SettingsProfile>
+                            </Tab.Pane>
+                            <Tab.Pane eventKey="appearance">
+                                <SettingsAppearance></SettingsAppearance>
+                            </Tab.Pane>
+                            <Tab.Pane eventKey="privacy">
+                                <SettingsPrivacy></SettingsPrivacy>
+                            </Tab.Pane>
+                        </Tab.Content>
+                    </Col>
+                </Row>
+            </Tab.Container>
+        </Container>
     );
 };
 

--- a/front-end/src/pages/Settings.js
+++ b/front-end/src/pages/Settings.js
@@ -1,0 +1,31 @@
+import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Card from "react-bootstrap/Card";
+import ListGroup from "react-bootstrap/ListGroup";
+
+const Settings = () => {
+    return (
+      <div className="App">
+        <Container>
+          <Row>
+            {/* Settings List */}
+            <Col>
+              <ListGroup>
+                <ListGroup.Item>Security</ListGroup.Item>
+              </ListGroup>
+            </Col>
+            {/* Current Settings Page */}
+            <Col sm={8}>
+              <Card>
+                <Card.Title>Account</Card.Title>
+              </Card>
+            </Col>
+          </Row>
+        </Container>
+      </div>
+    );
+  };
+  
+  export default Settings;
+  

--- a/front-end/src/pages/Settings.js
+++ b/front-end/src/pages/Settings.js
@@ -1,31 +1,57 @@
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import Card from "react-bootstrap/Card";
-import ListGroup from "react-bootstrap/ListGroup";
+import Tab from "react-bootstrap/Tab";
+import Nav from "react-bootstrap/Nav";
+import SettingsSecurity from "../components/SettingsSecurity.js";
+import SettingsProfile from "../components/SettingsProfile.js";
+import SettingsAppearance from "../components/SettingsAppearance.js";
+import SettingsPrivacy from "../components/SettingsPrivacy.js";
+import "../pages/Settings.css"
 
 const Settings = () => {
     return (
-      <div className="App">
-        <Container>
-          <Row>
-            {/* Settings List */}
-            <Col>
-              <ListGroup>
-                <ListGroup.Item>Security</ListGroup.Item>
-              </ListGroup>
-            </Col>
-            {/* Current Settings Page */}
-            <Col sm={8}>
-              <Card>
-                <Card.Title>Account</Card.Title>
-              </Card>
-            </Col>
-          </Row>
-        </Container>
-      </div>
+        <div>
+            <Container>
+                <Tab.Container transition={false} defaultActiveKey="security">
+                    <Row>
+                        <Col>
+                            <Nav variant="pills" className="settings-list flex-column">
+                                <Nav.Item>
+                                    <Nav.Link eventKey="security">Security</Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item>
+                                    <Nav.Link eventKey="profile">Profile</Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item>
+                                    <Nav.Link eventKey="appearance">Appearance</Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item>
+                                    <Nav.Link eventKey="privacy">Privacy</Nav.Link>
+                                </Nav.Item>
+                            </Nav>
+                        </Col>
+                        <Col sm={8}>
+                            <Tab.Content>
+                                <Tab.Pane eventKey="security">
+                                    <SettingsSecurity></SettingsSecurity>
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="profile">
+                                    <SettingsProfile></SettingsProfile>
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="appearance">
+                                    <SettingsAppearance></SettingsAppearance>
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="privacy">
+                                    <SettingsPrivacy></SettingsPrivacy>
+                                </Tab.Pane>
+                            </Tab.Content>
+                        </Col>
+                    </Row>
+                </Tab.Container>
+            </Container>
+        </div>
     );
-  };
-  
-  export default Settings;
-  
+};
+
+export default Settings;


### PR DESCRIPTION
This PR adds a shell for the Settings page.

* Added a button to the navbar that opens the Settings page
* Added a separate component for each settings page: Security, Profile, Appearance, Privacy
* Imported all components for Settings pages into Settings.js
* Created a tab container that holds the list of settings links and the settings
* Styled the tab links to match the wireframe

This closes #27 