### PR TITLE
refactor: Combine Task Add and Task List cards

### DIFF
--- a/front-end/src/components/TaskAdd.js
+++ b/front-end/src/components/TaskAdd.js
@@ -2,18 +2,25 @@ import Form from "react-bootstrap/Form";
 import DatePicker from "react-datepicker";
 import Button from "react-bootstrap/Button";
 import "react-datepicker/dist/react-datepicker.css";
-import { useState, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 
 //let link = "http://localhost:5050/"
 let link = "https://planned-out-backend-jdx6.onrender.com/"
 
-function TaskAdd() {
+const TaskAdd = ({trigger}) => {
 
     const [taskName, setNameInput] = useState(""); // New state for the name input
     const [taskDate, setDateInput] = useState("");
     const [taskDateOut, setDateOutput] = useState("");
     const [taskDesc, setDescInput] = useState(""); // New state for the name input
     const inputBox = useRef(null);
+
+    useEffect(() => {
+        if (trigger) {
+            alert("Test");
+          handleSubmit();
+        }
+      });
 
     const handleSubmit = (e) => {
         console.log("Test Task Add");

--- a/front-end/src/components/TaskAdd.js
+++ b/front-end/src/components/TaskAdd.js
@@ -1,26 +1,26 @@
 import Form from "react-bootstrap/Form";
 import DatePicker from "react-datepicker";
-import Button from "react-bootstrap/Button";
 import "react-datepicker/dist/react-datepicker.css";
-import { useState, useEffect, useRef } from "react";
+import { useState, forwardRef, useRef, useImperativeHandle } from "react";
 
 //let link = "http://localhost:5050/"
 let link = "https://planned-out-backend-jdx6.onrender.com/"
 
-const TaskAdd = ({trigger}) => {
-
+const TaskAdd = forwardRef((props, ref) => {
     const [taskName, setNameInput] = useState(""); // New state for the name input
     const [taskDate, setDateInput] = useState("");
     const [taskDateOut, setDateOutput] = useState("");
     const [taskDesc, setDescInput] = useState(""); // New state for the name input
     const inputBox = useRef(null);
 
-    useEffect(() => {
-        if (trigger) {
-            alert("Test");
-          handleSubmit();
-        }
-      });
+    useImperativeHandle(ref, () => ({
+        handleSubmit: handleSubmit,
+        getTaskName: getTaskName
+    }));
+
+    const getTaskName = () => {
+        return taskName;
+    }
 
     const handleSubmit = (e) => {
         console.log("Test Task Add");
@@ -102,9 +102,8 @@ const TaskAdd = ({trigger}) => {
                 onChange={(e) => handleDescInput(e)}
                 className="taskDescBox"
             />
-            <Button onClick={(e) => handleSubmit(e)}>Submit!</Button>
         </>
     )
-}
+});
 
 export default TaskAdd;

--- a/front-end/src/components/TaskList.js
+++ b/front-end/src/components/TaskList.js
@@ -16,7 +16,6 @@ function TaskList() {
 
     const [tasksList, setTaskList] = useState([]);
 
-
     function CheckBox({ id, taskID, taskName, taskDate, taskDesc, taskStatus }) {
         let labelID = id + "label";
         let checkedID = id + "checked";

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -48,6 +48,7 @@ div.card-title {
 
 div.task-list {
   border: none !important;
+  overflow: scroll;
 }
 
 div.task {

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -6,28 +6,33 @@ import Card from "react-bootstrap/Card";
 import CalendarView from "../components/CalendarView.js"
 import TaskAdd from "../components/TaskAdd.js"
 import TaskList from "../components/TaskList.js"
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 const Home = () => {
 
   const [isTaskListShown, setIsTaskListShown] = useState(true);
   const [isTaskAddShown, setIsTaskAddShown] = useState(false);
-  const [trigger, setTrigger] = useState(0);
 
-  function toggleTaskAdd() {
+  const taskAddRef = useRef();
+
+  function showTaskAdd() {
     // Show the Task Add card
     setIsTaskAddShown(current => !current);
     // Hide the Task List card
     setIsTaskListShown(false);
   }
 
-  function toggleTaskList() {
-    // Trigger the handle submit for Task Add
-    setTrigger((trigger) => trigger + 1)
-    // Show the Task List card
-    setIsTaskListShown(current => !current);
-    // Hide the Task Add card
-    setIsTaskAddShown(false);
+  function showTaskList() {
+    if (!(taskAddRef.current.getTaskName() === "")) {
+      // Show the Task List card
+      setIsTaskListShown(current => !current);
+      // Hide the Task Add card
+      setIsTaskAddShown(false);
+      taskAddRef.current.handleSubmit();
+    }
+    else {
+      alert("ERROR");
+    }
   }
 
   return (
@@ -44,15 +49,15 @@ const Home = () => {
                 {/* Spacer */}
                 <div className="d-flex flex-column"></div>
                 {/* Add a task button */}
-                <Button onClick={toggleTaskAdd} id="add-task-button">Add a task +</Button>
+                <Button onClick={showTaskAdd} id="add-task-button">Add a task +</Button>
               </Card>
             }
             {/* Task Add Card */}
             {isTaskAddShown &&
               <Card className="tasks-add">
                 <Card.Title>New Task</Card.Title>
-                <TaskAdd trigger={trigger}/>
-                <Button onClick={toggleTaskList}>Submit!</Button>
+                <TaskAdd ref={taskAddRef} />
+                <Button onClick={showTaskList}>Submit!</Button>
               </Card>
             }
           </Col>

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -3,23 +3,32 @@ import Row from "react-bootstrap/Row";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Card from "react-bootstrap/Card";
-import TaskList from "../components/TaskList.js"
 import CalendarView from "../components/CalendarView.js"
 import TaskAdd from "../components/TaskAdd.js"
+import TaskList from "../components/TaskList.js"
 import { useState } from "react";
 
 const Home = () => {
 
   const [isTaskListShown, setIsTaskListShown] = useState(true);
   const [isTaskAddShown, setIsTaskAddShown] = useState(false);
+  const [trigger, setTrigger] = useState(0);
 
   function toggleTaskAdd() {
+    // Show the Task Add card
     setIsTaskAddShown(current => !current);
+    // Hide the Task List card
     setIsTaskListShown(false);
   }
 
   function toggleTaskList() {
+    TaskAdd.handleSubmit();
+    // Trigger the handle submit for Task Add
+    //setTrigger((trigger) => trigger + 1)
+    // Show the Task List card
     setIsTaskListShown(current => !current);
+    // Hide the Task Add card
+    setIsTaskAddShown(false);
   }
 
   return (
@@ -43,7 +52,8 @@ const Home = () => {
             {isTaskAddShown &&
               <Card className="tasks-add">
                 <Card.Title>New Task</Card.Title>
-                <TaskAdd />
+                <TaskAdd trigger={trigger}/>
+                <Button onClick={toggleTaskList}>Submit!</Button>
               </Card>
             }
           </Col>

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -15,6 +15,7 @@ const Home = () => {
 
   function toggleTaskAdd() {
     setIsTaskAddShown(current => !current);
+    setIsTaskListShown(false);
   }
 
   function toggleTaskList() {

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -22,9 +22,8 @@ const Home = () => {
   }
 
   function toggleTaskList() {
-    TaskAdd.handleSubmit();
     // Trigger the handle submit for Task Add
-    //setTrigger((trigger) => trigger + 1)
+    setTrigger((trigger) => trigger + 1)
     // Show the Task List card
     setIsTaskListShown(current => !current);
     // Hide the Task Add card

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -6,33 +6,52 @@ import Card from "react-bootstrap/Card";
 import TaskList from "../components/TaskList.js"
 import CalendarView from "../components/CalendarView.js"
 import TaskAdd from "../components/TaskAdd.js"
+import { useState } from "react";
 
 const Home = () => {
+
+  const [isTaskListShown, setIsTaskListShown] = useState(true);
+  const [isTaskAddShown, setIsTaskAddShown] = useState(false);
+
+  function toggleTaskAdd() {
+    setIsTaskAddShown(current => !current);
+  }
+
+  function toggleTaskList() {
+    setIsTaskListShown(current => !current);
+  }
+
   return (
     <div className="App">
       <Container>
         <Row>
           <Col>
-            {/* Tasks Card */}
-            <Card className="tasks-card">
-              <Card.Title>Today's Tasks</Card.Title>
-              {/* List of Tasks */}
-              <TaskList />
-              {/* Spacer */}
-              <div className="d-flex flex-column"></div>
-              {/* Add a task button */}
-              <Button id="add-task-button">Add a task +</Button>
-            </Card>
-            <Card className="tasks-add">
-              <Card.Title>New Task</Card.Title>
-              <TaskAdd/>
-            </Card>
+            {/* Task List Card */}
+            {isTaskListShown &&
+              <Card className="tasks-card">
+                <Card.Title>Today's Tasks</Card.Title>
+                {/* List of Tasks */}
+                <TaskList />
+                {/* Spacer */}
+                <div className="d-flex flex-column"></div>
+                {/* Add a task button */}
+                <Button onClick={toggleTaskAdd} id="add-task-button">Add a task +</Button>
+              </Card>
+            }
+            {/* Task Add Card */}
+            {isTaskAddShown &&
+              <Card className="tasks-add">
+                <Card.Title>New Task</Card.Title>
+                <TaskAdd />
+              </Card>
+            }
           </Col>
+          {/* Calendar Card */}
           <Col sm={8}>
             <Card className="react-calendar">
               <Card.Title>Calendar</Card.Title>
               <div className="calendar-container">
-                <CalendarView/>
+                <CalendarView />
               </div>
             </Card>
           </Col>


### PR DESCRIPTION
This PR visually combines the task add and task list cards on the homepage. This makes it so that Task Add card is hidden until the user clicks 'Add a task'. Likewise, when the Task Add card is visible, the 'Submit' button will hide the Task Add card and make the Task List card visible.

* Add useState function to hide the Task Add card by default
* Add an onClick to the 'Add a task' button to show the Task Add card
* Add some missing comments
* Set the useState shown value of the Task List card to false when the add a task button is clicked
* Set the useState shown value of the Task Add card to false when the submit button is clicked
* Switched to using useImperativeHandle for handling the submit button between components
* This fixes tasks not actually being submitted to db when clicking submit after previous changes

This PR also makes the Task List scroll on overflow
* When there were too many tasks, the task list would get cut off. This allows the task list to be scrolled so it's not cut off.



This closes #22 