### PR TITLE
fix: Automatically update the task list after adding a task

### DIFF
--- a/back-end/server.mjs
+++ b/back-end/server.mjs
@@ -35,7 +35,12 @@ app.post("/add", async (req, res) => {
     };
     let collection = await db.collection("Tasks");
     let result = await collection.insertOne(newDocument);
-    res.send(result).status(204);
+    // Checks if the await is complete after certain timeout maybe do alert?
+    while (!result) {
+        res.status(500)
+    }
+    // maybe use a little refreshy status bar until it's done
+    res.send(result).status(201);
 });
 
 app.put("/updatetask/:id", async (req, res) => {

--- a/back-end/server.mjs
+++ b/back-end/server.mjs
@@ -35,11 +35,10 @@ app.post("/add", async (req, res) => {
     };
     let collection = await db.collection("Tasks");
     let result = await collection.insertOne(newDocument);
-    // Checks if the await is complete after certain timeout maybe do alert?
+    // Wait until the new task has reached the database
     while (!result) {
         res.status(500)
     }
-    // maybe use a little refreshy status bar until it's done
     res.send(result).status(201);
 });
 

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",


### PR DESCRIPTION
Previously when you used Task Add to add a task, the task wouldn't appear in the Task List until you refreshed the page. This PR fixes this by updating the POST request to wait until the task has reached the database before returning. This also updates a dependency.

* Add while statement to send status as not complete
* Add end of while will send 201 status on add task complete within the database
* NPM had me update a dependency to fix a vulnerability

This closes #21 