### PR TITLE
feat: Add accent color customization and automatic light/dark theme

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.2.0",
         "react-router-bootstrap": "^0.26.2",
         "react-scripts": "5.0.1",
+        "styled-components": "^6.1.0",
         "web-vitals": "^2.1.4"
       },
       "engines": {
@@ -2279,6 +2280,24 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -4534,6 +4553,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.2.tgz",
+      "integrity": "sha512-Rm17MsTpQQP5Jq4BF7CdrxJsDufoiL/q5IbJZYZmOZAJALyijgF7BzLgobXUqraNcQdqFYLYGeglDp6QzaxPpg=="
+    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
@@ -6001,6 +6025,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -6449,6 +6481,14 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
@@ -6629,6 +6669,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -16024,6 +16074,11 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16528,6 +16583,33 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.0.tgz",
+      "integrity": "sha512-VWNfYYBuXzuLS/QYEeoPgMErP26WL+dX9//rEh80B2mmlS1yRxRxuL5eax4m6ybYEUoHWlTy2XOU32767mlMkg==",
+      "dependencies": {
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/unitless": "^0.8.0",
+        "@types/stylis": "^4.0.2",
+        "css-to-react-native": "^3.2.0",
+        "csstype": "^3.1.2",
+        "postcss": "^8.4.31",
+        "shallowequal": "^1.1.0",
+        "stylis": "^4.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -16542,6 +16624,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/sucrase": {
       "version": "3.34.0",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-bootstrap": "^0.26.2",
     "react-scripts": "5.0.1",
+    "styled-components": "^6.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -42,6 +43,6 @@
     ]
   },
   "engines": {
-      "node": ">=14 <18.17.1"
+    "node": ">=14 <18.17.1"
   }
 }

--- a/front-end/src/components/SettingsAppearance.js
+++ b/front-end/src/components/SettingsAppearance.js
@@ -1,13 +1,26 @@
 import Card from "react-bootstrap/Card";
+import { useState, useRef, useEffect } from "react";
+import { ThemeProvider } from "styled-components";
+import { GlobalStyles } from '../themes/GlobalStyles.js';
+import { useTheme } from '../themes/useTheme';
+import ThemeSelector from '../themes/themeSelector.js';
 
 const SettingsCard = (props) => {
 
+    const { theme, themeLoaded } = useTheme();
+    const [selectedTheme, setSelectedTheme] = useState(theme);
+    useEffect(() => {
+        setSelectedTheme(theme);
+    }, [themeLoaded]);
+
     return (
-        <>
+        themeLoaded && <ThemeProvider theme={selectedTheme}>
+            <GlobalStyles />
             <Card className="settings-card">
                 <Card.Title>Appearance</Card.Title>
+                <ThemeSelector setter={ setSelectedTheme }/>
             </Card>
-        </>
+        </ThemeProvider>
     )
 
 }

--- a/front-end/src/components/SettingsAppearance.js
+++ b/front-end/src/components/SettingsAppearance.js
@@ -11,7 +11,7 @@ const SettingsCard = (props) => {
     const [selectedTheme, setSelectedTheme] = useState(theme);
     useEffect(() => {
         setSelectedTheme(theme);
-    }, [themeLoaded]);
+    }, [theme, themeLoaded]);
 
     return (
         themeLoaded && <ThemeProvider theme={selectedTheme}>

--- a/front-end/src/components/SettingsAppearance.js
+++ b/front-end/src/components/SettingsAppearance.js
@@ -1,8 +1,8 @@
 import Card from "react-bootstrap/Card";
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyles } from '../themes/GlobalStyles.js';
-import { useTheme } from '../themes/useTheme';
+import { useTheme } from '../themes/useTheme.js';
 import ThemeSelector from '../themes/themeSelector.js';
 
 const SettingsCard = (props) => {
@@ -18,7 +18,8 @@ const SettingsCard = (props) => {
             <GlobalStyles />
             <Card className="settings-card">
                 <Card.Title>Appearance</Card.Title>
-                <ThemeSelector setter={ setSelectedTheme }/>
+                <Card.Text className="accent-color">Accent Color</Card.Text>
+                <ThemeSelector setter={setSelectedTheme} />
             </Card>
         </ThemeProvider>
     )

--- a/front-end/src/components/TaskList.js
+++ b/front-end/src/components/TaskList.js
@@ -124,7 +124,7 @@ function TaskList() {
             </ListGroup.Item>
             {/* For loop for each task in the tasks list */}
             {tasksList.map((task) => (
-                <ListGroup.Item className="task">
+                <ListGroup.Item key={task._id} className="task">
                     <CheckBox
                         className="task"
                         id={"task" + tasksList.indexOf(task)}

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1,13 +1,33 @@
+/* ---- LIGHT MODE COLORS ---- */
 :root {
-  --default-color: #98d498;
-  --default-hover: #627262;
-  --default-click: #a5c1a5;
-  --default-nextMonth: #dfdfdf;
+  --background-color: #FFFFFF;
+  --text-color: #000000;
+  --card-background-color: var(--background-color);
+}
+
+/* ---- DARK MODE COLORS ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #121212;
+    --text-color: #d1cfcf;
+    --card-background-color: #3b3b3b;
+  }
 }
 
 body {
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+div.card, div.task-list {
+  background-color: var(--card-background-color) !important;
+  color: var(--text-color);
+}
+
+.list-group {
+  --bs-list-group-bg: var(--card-background-color);
 }
 
 code {
@@ -22,6 +42,11 @@ code {
   margin-bottom: 3em;
   padding: 1em;
 }
+
+.navbar-brand {
+  color: var(--text-color);
+}
+
 .navbar-brand img {
   margin-right: 10px;
 }
@@ -87,7 +112,6 @@ div.tasks-add button {
   width: 50%;
   margin: 5% auto 0px auto;
   border-radius: 24px;
-  background-color: var(--bs-btn-active-bg);
 }
 
 .react-datepicker-wrapper {
@@ -109,30 +133,37 @@ div.tasks-add .taskDescBox,
 .react-calendar {
   text-align: center;
 }
+
 .react-calendar__navigation {
   margin-bottom: 1em;
   display: flex;
 }
+
 .react-calendar__navigation__label {
   font-size: 1.5em;
   font-weight: bold;
 }
+
 .react-calendar__navigation__arrow {
   font-size: 1.5em;
   flex-grow: 0.333;
 }
+
 .react-calendar__month-view__weekdays {
   text-align: center;
+
   abbreviation {
     text-decoration: none;
   }
 }
+
 button {
   margin: 2px;
   background-color: var(--default-color);
   border: 0;
   color: white;
   height: 9vh;
+
   &:hover {
     background-color: var(--default-hover);
   }
@@ -141,6 +172,7 @@ button {
     background-color: var(--default-click);
   }
 }
+
 /* ~~~ day grid styles ~~~ */
 .react-calendar__month-view__days {
   display: grid !important;
@@ -150,10 +182,12 @@ button {
     max-width: initial !important;
   }
 }
+
 /* ~~~ neighboring month & weekend styles ~~~ */
 .react-calendar__month-view__days__day--neighboringMonth {
   opacity: 0.6;
 }
+
 .react-calendar__month-view__days__day--weekend {
   color: --;
 }
@@ -162,6 +196,7 @@ button {
 .react-calendar__tile--range {
   box-shadow: 0 0 6px 2px black;
 }
+
 /* ~~~ other view styles ~~~ */
 .react-calendar__year-view__months,
 .react-calendar__decade-view__years,
@@ -172,6 +207,7 @@ button {
   &.react-calendar__year-view__months {
     grid-template-columns: 33.3% 33.3% 33.3%;
   }
+
   .react-calendar__tile {
     max-width: initial !important;
   }
@@ -179,7 +215,7 @@ button {
 
 .unchecked {
   text-decoration: none !important;
-  color: black;
+  color: var(--text-color);
 }
 
 .checked {

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -190,3 +190,16 @@ button {
 .form-check-input[type="checkbox"] {
   margin-right: 1em;
 }
+
+div.theme-container {
+  display: grid;
+  grid-template-columns: repeat(4, auto);
+  width: 30%;
+}
+
+div.theme-container .btn {
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border-radius: 100%;
+}

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -194,12 +194,20 @@ button {
 div.theme-container {
   display: grid;
   grid-template-columns: repeat(4, auto);
+  row-gap: 1em;
+  column-gap: 1em;
+  margin-left: 0.5em;
   width: 30%;
 }
 
 div.theme-container .btn {
-  width: 20px;
-  height: 20px;
+  width: 50px;
+  height: 50px;
   padding: 0;
   border-radius: 100%;
+}
+
+p.accent-color {
+  margin-top: 1em;
+  font-size: 150%;
 }

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -94,6 +94,18 @@ div.task label {
   height: 80vh;
 }
 
+
+
+button, .btn, [type="button"]:not(:disabled) {
+  max-height: 50px;
+  border-radius: 24px;
+}
+
+div.react-calendar button, div.react-calendar [type="button"]:not(:disabled) {
+  max-height: none;
+  border-radius: 2px;
+}
+
 div.tasks-card button {
   width: 50%;
   margin: auto;

--- a/front-end/src/index.js
+++ b/front-end/src/index.js
@@ -19,8 +19,8 @@ export default function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
         </Route>
-        <Route path="/" element={<Layout />}>
-          <Route path="/login" element={<Login />} />
+        <Route path="/login" element={<Layout />}>
+          <Route index element={<Login />} />
         </Route>
         <Route path="/settings" element={<Layout />}>
           <Route index element={<Settings />} />

--- a/front-end/src/index.js
+++ b/front-end/src/index.js
@@ -7,8 +7,11 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "./index.css";
 import Registration from "./pages/Registration.js";
 import Settings from "./pages/Settings.js";
+import * as themes from './themes/schema.json';
+import { setToLS } from './utils/storage';
 
 export default function App() {
+  setToLS('all-themes', themes.default);
   return (
     <BrowserRouter>
       <Routes>

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -10,7 +10,6 @@ import { useState, useRef, useEffect } from "react";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyles } from '../themes/GlobalStyles.js';
 import { useTheme } from '../themes/useTheme';
-import  ThemeSelector from '../themes/themeSelector.js';
 
 const Home = () => {
 
@@ -19,7 +18,7 @@ const Home = () => {
 
   useEffect(() => {
     setSelectedTheme(theme);
-  }, [themeLoaded]);
+  }, [theme, themeLoaded]);
 
 
   const [isTaskListShown, setIsTaskListShown] = useState(true);

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -6,9 +6,21 @@ import Card from "react-bootstrap/Card";
 import CalendarView from "../components/CalendarView.js"
 import TaskAdd from "../components/TaskAdd.js"
 import TaskList from "../components/TaskList.js"
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
+import { ThemeProvider } from "styled-components";
+import { GlobalStyles } from '../themes/GlobalStyles.js';
+import { useTheme } from '../themes/useTheme';
+import  ThemeSelector from '../themes/themeSelector.js';
 
 const Home = () => {
+
+  const { theme, themeLoaded } = useTheme();
+  const [selectedTheme, setSelectedTheme] = useState(theme);
+
+  useEffect(() => {
+    setSelectedTheme(theme);
+  }, [themeLoaded]);
+
 
   const [isTaskListShown, setIsTaskListShown] = useState(true);
   const [isTaskAddShown, setIsTaskAddShown] = useState(false);
@@ -36,43 +48,49 @@ const Home = () => {
   }
 
   return (
-    <div className="App">
-      <Container>
-        <Row>
-          <Col>
-            {/* Task List Card */}
-            {isTaskListShown &&
-              <Card className="tasks-card">
-                <Card.Title>Today's Tasks</Card.Title>
-                {/* List of Tasks */}
-                <TaskList />
-                {/* Spacer */}
-                <div className="d-flex flex-column"></div>
-                {/* Add a task button */}
-                <Button onClick={showTaskAdd} id="add-task-button">Add a task +</Button>
+
+    themeLoaded && <ThemeProvider theme={selectedTheme}>
+      <GlobalStyles />
+      <div className="App">
+        <Container>
+          <Row>
+            <Col>
+              {/* Task List Card */}
+              {isTaskListShown &&
+                <Card className="tasks-card">
+                  <Card.Title>Today's Tasks</Card.Title>
+                  {/* List of Tasks */}
+                  <TaskList />
+                  {/* Spacer */}
+                  <div className="d-flex flex-column"></div>
+                  {/* Add a task button */}
+                  <Button onClick={showTaskAdd} id="add-task-button">Add a task +</Button>
+                </Card>
+              }
+              {/* Task Add Card */}
+              {isTaskAddShown &&
+                <Card className="tasks-add">
+                  <Card.Title>New Task</Card.Title>
+                  <TaskAdd ref={taskAddRef} />
+                  <Button onClick={showTaskList}>Submit!</Button>
+                </Card>
+              }
+            </Col>
+            {/* Calendar Card */}
+            <Col sm={8}>
+              <Card className="react-calendar">
+                <Card.Title>Calendar</Card.Title>
+                <div className="calendar-container">
+                  <CalendarView />
+                </div>
               </Card>
-            }
-            {/* Task Add Card */}
-            {isTaskAddShown &&
-              <Card className="tasks-add">
-                <Card.Title>New Task</Card.Title>
-                <TaskAdd ref={taskAddRef} />
-                <Button onClick={showTaskList}>Submit!</Button>
-              </Card>
-            }
-          </Col>
-          {/* Calendar Card */}
-          <Col sm={8}>
-            <Card className="react-calendar">
-              <Card.Title>Calendar</Card.Title>
-              <div className="calendar-container">
-                <CalendarView />
-              </div>
-            </Card>
-          </Col>
-        </Row>
-      </Container>
-    </div>
+            </Col>
+          </Row>
+        </Container>
+      </div>
+    </ThemeProvider>
+
+
   );
 };
 

--- a/front-end/src/pages/Home.js
+++ b/front-end/src/pages/Home.js
@@ -43,7 +43,7 @@ const Home = () => {
       taskAddRef.current.handleSubmit();
     }
     else {
-      alert("ERROR");
+      alert("ERROR. Task name is empty");
     }
   }
 

--- a/front-end/src/pages/Layout.js
+++ b/front-end/src/pages/Layout.js
@@ -16,7 +16,6 @@ const Layout = () => {
               width={"32px"}
               height={"32px"}
               alt={"Planned-Out Logo"}
-              paddingRight={"10px"}
             />
             Planned-Out
           </Navbar.Brand>

--- a/front-end/src/pages/Login.js
+++ b/front-end/src/pages/Login.js
@@ -1,14 +1,29 @@
 import Container from "react-bootstrap/Container";
 import LoginForm from "../components/LoginForm.js";
 import "./login.css";
+import { ThemeProvider } from "styled-components";
+import { GlobalStyles } from '../themes/GlobalStyles.js';
+import { useTheme } from '../themes/useTheme';
+import { useState, useEffect } from "react";
 
 const Login = () => {
+
+  const { theme, themeLoaded } = useTheme();
+  const [selectedTheme, setSelectedTheme] = useState(theme);
+
+  useEffect(() => {
+    setSelectedTheme(theme);
+  }, [theme, themeLoaded]);
+
   return (
-    <div className="App">
-      <Container className="login-container">
-        <LoginForm />
-      </Container>
-    </div>
+    themeLoaded && <ThemeProvider theme={selectedTheme}>
+      <GlobalStyles />
+      <div className="App">
+        <Container className="login-container">
+          <LoginForm />
+        </Container>
+      </div>
+    </ThemeProvider>
   );
 };
 export default Login;

--- a/front-end/src/pages/Registration.js
+++ b/front-end/src/pages/Registration.js
@@ -1,14 +1,29 @@
 import Container from "react-bootstrap/Container";
 import RegistrationForm from "../components/RegistrationForm.js";
 import "./registration.css";
+import { ThemeProvider } from "styled-components";
+import { GlobalStyles } from '../themes/GlobalStyles.js';
+import { useTheme } from '../themes/useTheme';
+import { useState, useEffect } from "react";
 
 const Registration = () => {
+
+  const { theme, themeLoaded } = useTheme();
+  const [selectedTheme, setSelectedTheme] = useState(theme);
+
+  useEffect(() => {
+    setSelectedTheme(theme);
+  }, [theme, themeLoaded]);
+
   return (
-    <div className="App">
-      <Container className="registration-container">
-        <RegistrationForm />
-      </Container>
-    </div>
+    themeLoaded && <ThemeProvider theme={selectedTheme}>
+      <GlobalStyles />
+      <div className="App">
+        <Container className="registration-container">
+          <RegistrationForm />
+        </Container>
+      </div>  
+    </ThemeProvider>
   );
 };
 export default Registration;

--- a/front-end/src/pages/Settings.css
+++ b/front-end/src/pages/Settings.css
@@ -10,7 +10,7 @@
     font-size: 150%;
     background-color: transparent !important;
     border-color: transparent !important;
-    color: black !important;
+    color: var(--text-color);
     text-align: left !important;
 }
 

--- a/front-end/src/pages/login.css
+++ b/front-end/src/pages/login.css
@@ -11,7 +11,7 @@
   border: 1px solid rgb(0, 0, 0);
   border-radius: 5%;
 }
-label {
+div.login-form label {
   padding: 5px;
 }
 .login-button {

--- a/front-end/src/pages/login.css
+++ b/front-end/src/pages/login.css
@@ -1,6 +1,6 @@
 .login-container {
   padding: 2px 16px; /* creates margins */
-  width: 20%;
+  width: 25vw;
   text-align: center;
 }
 .login-form {
@@ -9,7 +9,7 @@
   margin: 8px 0;
   box-sizing: border-box;
   border: 1px solid lightgray;
-  border-radius: 5%;
+  border-radius: 16px;
   background-color: var(--card-background-color);
 }
 

--- a/front-end/src/pages/login.css
+++ b/front-end/src/pages/login.css
@@ -8,9 +8,15 @@
   padding: 12px 20px;
   margin: 8px 0;
   box-sizing: border-box;
-  border: 1px solid rgb(0, 0, 0);
+  border: 1px solid lightgray;
   border-radius: 5%;
+  background-color: var(--card-background-color);
 }
+
+.form-text {
+  color: var(--text-color) !important;
+}
+
 div.login-form label {
   padding: 5px;
 }

--- a/front-end/src/pages/registration.css
+++ b/front-end/src/pages/registration.css
@@ -1,6 +1,6 @@
 .registration-container {
   padding: 2px 16px; /* creates margins */
-  width: 20%;
+  width: 20vw;
 }
 .form-group {
   width: 100%;
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   border: 1px solid lightgray;
   text-align: left;
-  border-radius: 5%;
+  border-radius: 16px;
   background-color: var(--card-background-color);
 }
 Form {

--- a/front-end/src/pages/registration.css
+++ b/front-end/src/pages/registration.css
@@ -7,9 +7,10 @@
   padding: 12px 20px;
   margin: 8px 0;
   box-sizing: border-box;
-  border: 1px solid rgb(0, 0, 0);
+  border: 1px solid lightgray;
   text-align: left;
   border-radius: 5%;
+  background-color: var(--card-background-color);
 }
 Form {
   text-align: center;

--- a/front-end/src/themes/GlobalStyles.js
+++ b/front-end/src/themes/GlobalStyles.js
@@ -1,0 +1,13 @@
+import { createGlobalStyle} from "styled-components";
+
+export const GlobalStyles = createGlobalStyle`
+  .btn, .btn.active {
+    background: ${({ theme }) => theme.colors.accent};
+    border-color: ${({ theme }) => theme.colors.accent};
+  }
+
+  div.react-calendar button {
+    background: ${({ theme }) => theme.colors.accent};
+    border-color: ${({ theme }) => theme.colors.accent};
+  }
+`;

--- a/front-end/src/themes/GlobalStyles.js
+++ b/front-end/src/themes/GlobalStyles.js
@@ -1,7 +1,7 @@
 import { createGlobalStyle} from "styled-components";
 
 export const GlobalStyles = createGlobalStyle`
-  .btn, .btn.active, .btn:hover {
+  .btn, .btn.active, .btn:hover, .btn:disabled {
     background: ${({ theme }) => theme.colors.accent};
     border-color: ${({ theme }) => theme.colors.accent};
   }

--- a/front-end/src/themes/GlobalStyles.js
+++ b/front-end/src/themes/GlobalStyles.js
@@ -1,9 +1,14 @@
 import { createGlobalStyle} from "styled-components";
 
 export const GlobalStyles = createGlobalStyle`
-  .btn, .btn.active {
+  .btn, .btn.active, .btn:hover {
     background: ${({ theme }) => theme.colors.accent};
     border-color: ${({ theme }) => theme.colors.accent};
+  }
+
+  div.nav-item .btn.active, div.nav-item .btn:hover {
+    background: ${({ theme }) => theme.colors.accent} !important;
+    border-color: ${({ theme }) => theme.colors.accent} !important;
   }
 
   div.react-calendar button {

--- a/front-end/src/themes/GlobalStyles.js
+++ b/front-end/src/themes/GlobalStyles.js
@@ -15,4 +15,9 @@ export const GlobalStyles = createGlobalStyle`
     background: ${({ theme }) => theme.colors.accent};
     border-color: ${({ theme }) => theme.colors.accent};
   }
-`;
+
+  .form-check-input:checked[type="checkbox"] {
+    background-color: ${({ theme }) => theme.colors.accent};
+    border-color: ${({ theme }) => theme.colors.accent};
+  }
+`;  

--- a/front-end/src/themes/schema.json
+++ b/front-end/src/themes/schema.json
@@ -36,10 +36,24 @@
         }
       },
       "mint" : {
-        "id": "T_005",
+        "id": "T_006",
         "name": "Mint",
         "colors": {
           "accent": "#3eb489"
+        }
+      },
+      "pink" : {
+        "id": "T_007",
+        "name": "Pink",
+        "colors": {
+          "accent": "#ff9999"
+        }
+      },
+      "grey" : {
+        "id": "T_008",
+        "name": "Grey",
+        "colors": {
+          "accent": "grey"
         }
       }
     }

--- a/front-end/src/themes/schema.json
+++ b/front-end/src/themes/schema.json
@@ -13,6 +13,34 @@
         "colors": {
           "accent": "#0962E6"
         }
+      },
+      "green" : {
+        "id": "T_003",
+        "name": "Green",
+        "colors": {
+          "accent": "#03ba02"
+        }
+      },
+      "purple" : {
+        "id": "T_004",
+        "name": "Purple",
+        "colors": {
+          "accent": "#ab00c1"
+        }
+      },
+      "orange" : {
+        "id": "T_005",
+        "name": "Orange",
+        "colors": {
+          "accent": "#e3a017"
+        }
+      },
+      "mint" : {
+        "id": "T_005",
+        "name": "Mint",
+        "colors": {
+          "accent": "#3eb489"
+        }
       }
     }
   }

--- a/front-end/src/themes/schema.json
+++ b/front-end/src/themes/schema.json
@@ -1,0 +1,18 @@
+{
+    "data" : {
+      "red" : {
+        "id": "T_001",
+        "name": "Red",
+        "colors": {
+          "accent": "#E60909"
+        }
+      },
+      "blue" : {
+        "id": "T_002",
+        "name": "Blue",
+        "colors": {
+          "accent": "#0962E6"
+        }
+      }
+    }
+  }

--- a/front-end/src/themes/themeSelector.js
+++ b/front-end/src/themes/themeSelector.js
@@ -26,23 +26,23 @@ const Switch = (props) => {
             <>
                 <Button onClick={(theme) => themeSwitcher(props.theme)}
                     style={{
-                        backgroundColor: props.theme.accent,
-                        color: `black`,
+                        backgroundColor: props.theme.colors.accent,
+                        borderColor: props.theme.colors.accent,
                     }}>
-                    {props.theme.name}
                 </Button>
             </>
         )
     }
 
     return (
-        <>                {
-            themes.length > 0 &&
-            themes.map(theme => (
-                <ThemeButton theme={data[theme]} key={data[theme].id} />
-            ))
-        }
-        </>
+        <div class="theme-container">
+            {
+                themes.length > 0 &&
+                themes.map(theme => (
+                    <ThemeButton theme={data[theme]} key={data[theme].id} />
+                ))
+            }
+        </div>
     )
 }
 

--- a/front-end/src/themes/themeSelector.js
+++ b/front-end/src/themes/themeSelector.js
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from "react";
+import _ from 'lodash';
+import { useTheme } from '../themes/useTheme';
+import { getFromLS } from '../utils/storage';
+import Button from 'react-bootstrap/Button';
+
+const Switch = (props) => {
+    const themesFromStore = getFromLS('all-themes');
+    const [data] = useState(themesFromStore.data);
+    const [themes, setThemes] = useState([]);
+    const { setMode } = useTheme();
+
+    const themeSwitcher = selectedTheme => {
+        console.log(selectedTheme);
+        setMode(selectedTheme);
+        props.setter(selectedTheme);
+    };
+
+    useEffect(() => {
+        setThemes(_.keys(data));
+    }, [data]);
+
+
+    const ThemeButton = props => {
+        return (
+            <>
+                <Button onClick={(theme) => themeSwitcher(props.theme)}
+                    style={{
+                        backgroundColor: props.theme.accent,
+                        color: `black`,
+                    }}>
+                    {props.theme.name}
+                </Button>
+            </>
+        )
+    }
+
+    return (
+        <>                {
+            themes.length > 0 &&
+            themes.map(theme => (
+                <ThemeButton theme={data[theme]} key={data[theme].id} />
+            ))
+        }
+        </>
+    )
+}
+
+export default Switch;

--- a/front-end/src/themes/themeSelector.js
+++ b/front-end/src/themes/themeSelector.js
@@ -35,7 +35,7 @@ const Switch = (props) => {
     }
 
     return (
-        <div class="theme-container">
+        <div className="theme-container">
             {
                 themes.length > 0 &&
                 themes.map(theme => (

--- a/front-end/src/themes/useTheme.js
+++ b/front-end/src/themes/useTheme.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { setToLS, getFromLS } from '../utils/storage';
+
+export const useTheme = () => {
+  const themes = getFromLS('all-themes');
+  const [theme, setTheme] = useState(themes.data.blue);
+  const [themeLoaded, setThemeLoaded] = useState(false);
+
+  const setMode = mode => {
+    setToLS('theme', mode)
+    setTheme(mode);
+  };
+
+  useEffect(() =>{
+    const localTheme = getFromLS('theme');
+    localTheme ? setTheme(localTheme) : setTheme(themes.data.blue);
+    setThemeLoaded(true);
+  }, []);
+
+  return { theme, themeLoaded, setMode };
+};

--- a/front-end/src/utils/storage.js
+++ b/front-end/src/utils/storage.js
@@ -1,0 +1,11 @@
+export const setToLS = (key, value) => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }
+  
+  export const getFromLS = key => {
+    const value = window.localStorage.getItem(key);
+  
+    if (value) {
+      return JSON.parse(value);
+    }
+  }


### PR DESCRIPTION
This PR adds an accent color selection section to the Settings > Appearance page. Currently there are eight colors to choose from, though the colors themselves do need to be adjusted for better contrast. The accent color applies to all buttons on the site, and works across different pages.

This PR also adds automatic light/dark theme switching based on the user's system theme. For example, if a user has their device theme set to dark mode, then the website will automatically be in dark mode.

Finally, a few small tweaks were made:
* fix: Remove logo attribute causing console errors
* fix: Fix the className attribute of a div in themeSelector.js
* fix: Declare a new key for each ListGroup.Item in the task list
* fix: Prevent login.css label from messing with other css

This closes #40 

