### PR TITLE
feat: Implement privacy settings

### DIFF
--- a/back-end/server.mjs
+++ b/back-end/server.mjs
@@ -18,7 +18,7 @@ app.listen(PORT, () => {
 
 app.get("/hello-world", async (req, res) => {
     res.send(data);
-    console.log(data.message);
+    //console.log(data.message);
 });
 
 // POST for registering user information
@@ -40,7 +40,7 @@ app.post("/register", async (req, res) => {
     const collections = await db.listCollections().toArray();
     const existingCollection = collections.find(collection => collection.name === username);
 
-    console.log(existingCollection);
+    //console.log(existingCollection);
 
     // check collections length
     if (!existingCollection) {
@@ -49,11 +49,11 @@ app.post("/register", async (req, res) => {
         let result = await collection.insertOne(userInfo);
         res.status(200);
         res.send(result);
-        console.log("Super Unique")
+        //console.log("Super Unique")
     } else {
         res.status(500);
-        res.send({"Error": "User already exists"});
-        console.log("Not so unique")
+        res.send({ "Error": "User already exists" });
+        //console.log("Not so unique")
     }
 });
 
@@ -72,7 +72,7 @@ app.post("/add", async (req, res) => {
         res.status(500);
     }
     res.send(result).status(201);
-    console.log("ADDED TASK")
+    //console.log("ADDED TASK")
 });
 
 app.put("/updatetask/:id", async (req, res) => {
@@ -87,12 +87,12 @@ app.put("/updatetask/:id", async (req, res) => {
         );
 
         res.send(result).status(204);
-        console.log(result);
+        //console.log(result);
     }
     else {
-        console.log("ERROR: The new status is null");
+        //console.log("ERROR: The new status is null");
     }
-    console.log("ID: " + taskID + " New Status: " + newStatus);
+    //console.log("ID: " + taskID + " New Status: " + newStatus);
 });
 
 app.post("/login", async (req, res) => {
@@ -104,25 +104,25 @@ app.post("/login", async (req, res) => {
     let collection = await db.collection(username);
     // Get the information for the given user
     let results = await collection.find({ "pwd": hashedPwd }).toArray();
-    
+
     // Send user's info to frontend if successful
     if (results.length > 0) {
-        console.log(results.length);
+        //console.log(results.length);
         res.status(200);
         res.send({ "username": username });
     } // if unsuccessful, send error
     else {
-        console.log("ERROR: The new status is null");
+        //console.log("ERROR: The new status is null");
         res.status(403);
         res.send({ "Status": "Error" });
     }
-    console.log(results);
+    //console.log(results);
 });
 
 app.post("/:username", async (req, res) => {
     // Grabbing our username from the URL
     const username = req.body.username;
-    console.log(username)
+    //console.log(username)
 
     // Select tasks collection to find our user's tasks specifically
     let collection = await db.collection("Tasks");
@@ -131,37 +131,52 @@ app.post("/:username", async (req, res) => {
     let results = await collection.find({ "user": username }).toArray();
 
     // display results for testing
-    console.log("results: ", results);
+    //console.log("results: ", results);
 
     res.send(results).status(200);
 });
 
 app.put("/update", async (req, res) => {    // update user password
-    console.log("update: " + req.body.username);
+    //console.log("update: " + req.body.username);
     const username = req.body.username;
     const hashedPwd = await bcrypt.hashSync(req.body.password, salt);   // hash user password
-    console.log(username);
-    console.log(hashedPwd);
+    //console.log(username);
+    //console.log(hashedPwd);
     // Connect to the Users collection.
     let collection = await db.collection(username);
     // Get the information for the given user
     let results = await collection.find({ "pwd": hashedPwd }).toArray();
-    console.log(results.length);
+    //console.log(results.length);
     const newPwd = await bcrypt.hashSync(req.body.newPassword, salt);
-    console.log(newPwd);
+    //console.log(newPwd);
     if (results.length > 0) {   // check if password is correct
-      
-      let updatePassword = await db.collection(username).updateOne(
-        { "user": username },
-        { $set: { "pwd": newPwd }}
-      )
+
+        let updatePassword = await db.collection(username).updateOne(
+            { "user": username },
+            { $set: { "pwd": newPwd } }
+        )
         res.status(200);
         res.send({ "username": username });   // send new password
     }
     else {
-        console.log("ERROR: The new status is null");
+        //console.log("ERROR: The new status is null");
         res.status(403);
         res.send({ "Status": "Error" });
     }
-    console.log(results);
-  });
+    //console.log(results);
+});
+
+app.put("/delete-all-tasks", async (req, res) => {
+    // Get the username
+    const username = req.body.username;
+
+    console.log("DELETE TASKS USERNAME IS ",username);
+    // Get the Tasks collection
+    let collection = await db.collection("Tasks");
+    // Delete all of that user's tasks
+    let result = await collection.deleteMany( {"user": username } );
+
+    // Send result and log
+    res.send(result).status(201);
+    console.log("ALL TASKS FOR", username, "DELETED");
+});

--- a/back-end/server.mjs
+++ b/back-end/server.mjs
@@ -170,7 +170,7 @@ app.put("/delete-all-tasks", async (req, res) => {
     // Get the username
     const username = req.body.username;
 
-    console.log("DELETE TASKS USERNAME IS ",username);
+    //console.log("DELETE TASKS USERNAME IS ",username);
     // Get the Tasks collection
     let collection = await db.collection("Tasks");
     // Delete all of that user's tasks
@@ -178,5 +178,19 @@ app.put("/delete-all-tasks", async (req, res) => {
 
     // Send result and log
     res.send(result).status(201);
-    console.log("ALL TASKS FOR", username, "DELETED");
+    //console.log("ALL TASKS FOR", username, "DELETED");
+});
+
+app.put("/delete-account", async (req, res) => {
+    // Get the username
+    const username = req.body.username;
+
+    // Get the Tasks collection
+    let collection = await db.collection(username);
+    // Drop the user's collection
+    let result = await collection.drop();
+
+    // Send result and log
+    res.send(result).status(201);
+    //console.log("ACCOUNT", username, "DELETED");
 });

--- a/front-end/src/components/CalendarView.js
+++ b/front-end/src/components/CalendarView.js
@@ -1,8 +1,7 @@
 import Calendar from "react-calendar";
 import { useState, useEffect } from "react";
 
-//let link = "http://localhost:5050/"
-let link = "https://planned-out-backend-jdx6.onrender.com/"
+let link = localStorage.getItem("backendURL");
 
 function CalendarView({ username }) {
     const [date, setDate] = useState(new Date());

--- a/front-end/src/components/LoginForm.js
+++ b/front-end/src/components/LoginForm.js
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from "react";
 
 
-let link = localStorage.getItem("backendURL");;
+let link = localStorage.getItem("backendURL");
 
 function LoginForm() {
     const [username, setUsername] = useState("");

--- a/front-end/src/components/LoginForm.js
+++ b/front-end/src/components/LoginForm.js
@@ -4,8 +4,8 @@ import Text from "react-bootstrap/FormText";
 import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from "react";
 
- let link = "https://planned-out-backend-jdx6.onrender.com/";
-//let link = "http://localhost:5050/";
+
+let link = localStorage.getItem("backendURL");;
 
 function LoginForm() {
     const [username, setUsername] = useState("");

--- a/front-end/src/components/RegistrationForm.js
+++ b/front-end/src/components/RegistrationForm.js
@@ -3,8 +3,8 @@ import Button from "react-bootstrap/Button";
 import { useState } from "react";
 import { useNavigate } from 'react-router-dom';
 
-//let link = "http://localhost:5050/"
-let link = "https://planned-out-backend-jdx6.onrender.com/";
+let link = localStorage.getItem("backendURL");
+
 
 function RegistrationForm() {
   const [firstName, setFirstName] = useState("");

--- a/front-end/src/components/SettingsAppearance.js
+++ b/front-end/src/components/SettingsAppearance.js
@@ -18,7 +18,7 @@ const SettingsCard = (props) => {
             <GlobalStyles />
             <Card className="settings-card">
                 <Card.Title>Appearance</Card.Title>
-                <Card.Text className="accent-color">Accent Color</Card.Text>
+                <Card.Text className="settings-section">Accent Color</Card.Text>
                 <ThemeSelector setter={setSelectedTheme} />
             </Card>
         </ThemeProvider>

--- a/front-end/src/components/SettingsPrivacy.js
+++ b/front-end/src/components/SettingsPrivacy.js
@@ -3,6 +3,9 @@ import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 import { useState } from "react";
 
+let link = "http://localhost:5050/"
+//let link = "https://planned-out-backend-jdx6.onrender.com/"
+
 const SettingsCard = (props) => {
 
     const [showTaskDelete, setTaskDeleteShow] = useState(false);
@@ -14,7 +17,19 @@ const SettingsCard = (props) => {
     const handleAccountDeleteShow = () => setAccountDeleteShow(true);
 
     function deleteTasks() {
-        alert("All tasks deleted");
+        // Send the delete request to the server
+        fetch(link + "delete-all-tasks", {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                username: localStorage.getItem("user")
+            }),
+        })
+            .then((res) => {
+                res.json();
+            })
         // Hide the modal
         setTaskDeleteShow(false);
     }

--- a/front-end/src/components/SettingsPrivacy.js
+++ b/front-end/src/components/SettingsPrivacy.js
@@ -4,8 +4,8 @@ import Modal from "react-bootstrap/Modal";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-let link = "http://localhost:5050/"
-//let link = "https://planned-out-backend-jdx6.onrender.com/"
+//let link = "http://localhost:5050/"
+let link = "https://planned-out-backend-jdx6.onrender.com/"
 
 const SettingsCard = (props) => {
 
@@ -69,10 +69,10 @@ const SettingsCard = (props) => {
         <>
             <Card className="settings-card">
                 <Card.Title>Privacy</Card.Title>
-                <Card.Subtitle>Delete all tasks</Card.Subtitle>
-                <Button onClick={handleTaskDeleteShow}>Delete all tasks</Button>
-                <Card.Subtitle>Delete account</Card.Subtitle>
-                <Button onClick={handleAccountDeleteShow}>Delete account</Button>
+                <Card.Text className="settings-section">Delete all tasks</Card.Text>
+                <Button className="delete-button" onClick={handleTaskDeleteShow}>Delete all tasks</Button>
+                <Card.Text className="settings-section">Delete Account</Card.Text>
+                <Button className="delete-button" onClick={handleAccountDeleteShow}>Delete account</Button>
             </Card>
 
             <Modal show={showTaskDelete} onHide={handleTaskDeleteClose}>
@@ -81,7 +81,7 @@ const SettingsCard = (props) => {
                 </Modal.Header>
                 <Modal.Body>Are you sure you want to delete all of your tasks? This action cannot be reversed.</Modal.Body>
                 <Modal.Footer>
-                    <Button onClick={deleteTasks}>
+                    <Button className="danger" onClick={deleteTasks}>
                         Delete all tasks
                     </Button>
                     <Button onClick={handleTaskDeleteClose}>
@@ -96,10 +96,10 @@ const SettingsCard = (props) => {
                 </Modal.Header>
                 <Modal.Body>Are you sure you want to delete your account? This action cannot be reversed.</Modal.Body>
                 <Modal.Footer>
-                    <Button onClick={deleteAccount}>
+                    <Button className="danger" onClick={deleteAccount}>
                         Delete account
                     </Button>
-                    <Button onClick={handleAccountDeleteClose}>
+                    <Button classNAme onClick={handleAccountDeleteClose}>
                         Cancel
                     </Button>
 

--- a/front-end/src/components/SettingsPrivacy.js
+++ b/front-end/src/components/SettingsPrivacy.js
@@ -1,12 +1,71 @@
 import Card from "react-bootstrap/Card";
+import Button from "react-bootstrap/Button";
+import Modal from "react-bootstrap/Modal";
+import { useState } from "react";
 
 const SettingsCard = (props) => {
+
+    const [showTaskDelete, setTaskDeleteShow] = useState(false);
+    const [showAccountDelete, setAccountDeleteShow] = useState(false);
+
+    const handleTaskDeleteClose = () => setTaskDeleteShow(false);
+    const handleTaskDeleteShow = () => setTaskDeleteShow(true);
+    const handleAccountDeleteClose = () => setAccountDeleteShow(false);
+    const handleAccountDeleteShow = () => setAccountDeleteShow(true);
+
+    function deleteTasks() {
+        alert("All tasks deleted");
+        // Hide the modal
+        setTaskDeleteShow(false);
+    }
+
+    function deleteAccount() {
+        alert("Account deleted");
+        // Hide the modal
+        setAccountDeleteShow(false);
+    }
+
 
     return (
         <>
             <Card className="settings-card">
                 <Card.Title>Privacy</Card.Title>
+                <Card.Subtitle>Delete all tasks</Card.Subtitle>
+                <Button onClick={handleTaskDeleteShow}>Delete all tasks</Button>
+                <Card.Subtitle>Delete account</Card.Subtitle>
+                <Button onClick={handleAccountDeleteShow}>Delete account</Button>
             </Card>
+
+            <Modal show={showTaskDelete} onHide={handleTaskDeleteClose}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Delete All Tasks</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>Are you sure you want to delete all of your tasks? This action cannot be reversed.</Modal.Body>
+                <Modal.Footer>
+                    <Button onClick={deleteTasks}>
+                        Delete all tasks
+                    </Button>
+                    <Button onClick={handleTaskDeleteClose}>
+                        Cancel
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+
+            <Modal show={showAccountDelete} onHide={handleAccountDeleteClose}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Delete Account</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>Are you sure you want to delete your account? This action cannot be reversed.</Modal.Body>
+                <Modal.Footer>
+                    <Button onClick={deleteAccount}>
+                        Delete account
+                    </Button>
+                    <Button onClick={handleAccountDeleteClose}>
+                        Cancel
+                    </Button>
+
+                </Modal.Footer>
+            </Modal>
         </>
     )
 

--- a/front-end/src/components/SettingsPrivacy.js
+++ b/front-end/src/components/SettingsPrivacy.js
@@ -4,8 +4,7 @@ import Modal from "react-bootstrap/Modal";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-//let link = "http://localhost:5050/"
-let link = "https://planned-out-backend-jdx6.onrender.com/"
+let link = localStorage.getItem("backendURL");
 
 const SettingsCard = (props) => {
 

--- a/front-end/src/components/SettingsPrivacy.js
+++ b/front-end/src/components/SettingsPrivacy.js
@@ -2,11 +2,14 @@ import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 let link = "http://localhost:5050/"
 //let link = "https://planned-out-backend-jdx6.onrender.com/"
 
 const SettingsCard = (props) => {
+
+    const navigate = useNavigate();
 
     const [showTaskDelete, setTaskDeleteShow] = useState(false);
     const [showAccountDelete, setAccountDeleteShow] = useState(false);
@@ -35,9 +38,30 @@ const SettingsCard = (props) => {
     }
 
     function deleteAccount() {
-        alert("Account deleted");
+        // First, delete all of the tasks
+        deleteTasks();
+        // Then, send a delete account request to the server
+        fetch(link + "delete-account", {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                username: localStorage.getItem("user")
+            }),
+        })
+            .then((res) => {
+                res.json();
+            })
+
         // Hide the modal
         setAccountDeleteShow(false);
+
+        // Delete the user from local storage
+        localStorage.removeItem("user");
+
+        // Navigate to login page
+        navigate(`/login`);
     }
 
 

--- a/front-end/src/components/SettingsSecurity.js
+++ b/front-end/src/components/SettingsSecurity.js
@@ -3,7 +3,7 @@ import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import { useState } from "react";
 
-let link = localStorage.getItem("backendURL");;
+let link = localStorage.getItem("backendURL");
 
 const SettingsCard = (props) => {
     const [username, setUsername] = useState("");

--- a/front-end/src/components/SettingsSecurity.js
+++ b/front-end/src/components/SettingsSecurity.js
@@ -2,8 +2,8 @@ import Card from "react-bootstrap/Card";
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import { useState } from "react";
-let link = "https://planned-out-backend-jdx6.onrender.com/";
-//let link = "http://localhost:5050/";
+
+let link = localStorage.getItem("backendURL");;
 
 const SettingsCard = (props) => {
     const [username, setUsername] = useState("");

--- a/front-end/src/components/TaskAdd.js
+++ b/front-end/src/components/TaskAdd.js
@@ -3,8 +3,7 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { useState, forwardRef, useRef, useImperativeHandle } from "react";
 
-//let link = "http://localhost:5050/"
-let link = "https://planned-out-backend-jdx6.onrender.com/"
+let link = localStorage.getItem("backendURL");
 
 const TaskAdd = forwardRef((props, ref) => {
     const [taskName, setNameInput] = useState(""); // New state for the name input
@@ -42,8 +41,6 @@ const TaskAdd = forwardRef((props, ref) => {
                 .then((res) => {
                     res.json();
                 })
-                .then((data) => { });
-            //window.location.reload()
             console.log("Successfully added task!");
         } else {
             alert("Task must be named and have a date.");

--- a/front-end/src/components/TaskList.js
+++ b/front-end/src/components/TaskList.js
@@ -3,8 +3,7 @@ import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
 import { useState, useEffect } from "react";
 
-//let link = "http://localhost:5050/"
-let link = "https://planned-out-backend-jdx6.onrender.com/"
+let link = localStorage.getItem("backendURL");
 
 function TaskList({ username }) {
     console.log(username);

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -2,6 +2,7 @@
 :root {
   --background-color: #FFFFFF;
   --text-color: #000000;
+  --text-color-filter: invert(0%) sepia(100%) saturate(0%) hue-rotate(21deg) brightness(97%) contrast(103%);
   --card-background-color: var(--background-color);
 }
 
@@ -10,6 +11,7 @@
   :root {
     --background-color: #121212;
     --text-color: #d1cfcf;
+    --text-color-filter: invert(93%) sepia(18%) saturate(13%) hue-rotate(314deg) brightness(90%) contrast(84%);
     --card-background-color: #3b3b3b;
   }
 }
@@ -265,7 +267,7 @@ div.theme-container .btn {
   border-radius: 100%;
 }
 
-p.accent-color {
+p.settings-section {
   margin-top: 1em;
   font-size: 150%;
 }

--- a/front-end/src/pages/Layout.js
+++ b/front-end/src/pages/Layout.js
@@ -8,6 +8,18 @@ import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from "react";
 
 const Layout = () => {
+  // For testing purposes: Store the backend link in localStorage 
+  // so that it can be pulled from any page. This makes it so that
+  // we don't have to change the backend link on every single page
+  // when testing things with localhost
+  let renderBackend = "https://planned-out-backend-jdx6.onrender.com/";
+  let localBackend = "http://localhost:5050/"
+
+  // Use render backend
+  localStorage.setItem("backendURL", renderBackend);
+  // Use local backend
+  //localStorage.setItem("backendURL", localBackend);
+
   const navigate = useNavigate();
   const userCookie = localStorage.getItem('user');
   const [isUserLoggedIn, setLoggedIn] = useState([]);

--- a/front-end/src/pages/Settings.css
+++ b/front-end/src/pages/Settings.css
@@ -29,3 +29,31 @@
 .main-settings-container {
     width: 75vw;
 }
+
+.modal-content {
+    background-color: var(--card-background-color);
+}
+
+.modal-content .btn {
+    border-radius: 10px;
+}
+
+.btn-close {
+    filter: var(--text-color-filter);
+}
+
+.modal-content .danger, .modal-content .danger:hover {
+    background-color: #dc3545 !important;
+    border-color: #dc3545 !important;
+}
+
+.danger:hover {
+    opacity: 80%;
+}
+
+.delete-button, .delete-button:hover {
+    background-color: #dc3545 !important;
+    border-color: #dc3545 !important;
+    width: 30%;
+    border-radius: 10px !important;
+}


### PR DESCRIPTION
This PR implements privacy settings that allow a user to delete all of their tasks and/or their entire account. To prevent accidental clicks, a modal pops up to validate the user's choice. 

When a user chooses to delete all of their tasks, the server deleted all of the tasks associated with their username from the database.
When a user chooses to delete their account, the server first deletes all of their tasks then deletes the entire user's collection from the database. 

Changes:
* Added a button for delete all tasks
* Added a button for delete account
* Added modals for both to confirm
* Implemented backend code to delete all tasks
* Add backend code to delete account
* Frontend: Make sure that tasks are deleted before deleting the account
* Frontend: Make sure the user it removed from local storage after the account is deleted
* Frontend: Navigate to the login page after deleting account
* Fix spacing, size, and color of delete buttons
* Fix modal colors in dark mode
* Increase size of settings section titles

Additionally, a small change was made to make developing for the backend to be easier. 
* Store the backend URL in localStorage. Now it can be pulled from any page. This makes it so that we don't have to change the backend link on every single page when testing things with localhost.

This PR closes #46 

