### PR TITLE
fix: Fix crash caused by profile picture fetch

### DIFF
--- a/back-end/server.mjs
+++ b/back-end/server.mjs
@@ -174,7 +174,7 @@ app.put("/delete-all-tasks", async (req, res) => {
     // Get the Tasks collection
     let collection = await db.collection("Tasks");
     // Delete all of that user's tasks
-    let result = await collection.deleteMany( {"user": username } );
+    let result = await collection.deleteMany({ "user": username });
 
     // Send result and log
     res.send(result).status(201);
@@ -216,11 +216,14 @@ app.put("/get-profile-picture", async (req, res) => {
 
     // Get the user's collection
     let collection = await db.collection(username);
-    // Get the profile pic type
-    let result = await collection.findOne({user: username}, {$get: "profile_picture"} );
-    //console.log("RESULT", result);
 
-    // Send result and log
-    res.send(result).status(201);
-    //console.log("FETCHED PROFILE PIC");
+    // Only try to get the profile picture if the user exists 
+    if (collection) {
+        // Get the profile pic type
+        let result = await collection.findOne({ user: username }, { $get: "profile_picture" });
+        res.send(result).status(201);
+    }
+    else {
+        res.status(400);
+    };
 });

--- a/front-end/src/pages/Layout.js
+++ b/front-end/src/pages/Layout.js
@@ -36,20 +36,21 @@ const Layout = () => {
   })
 
   useLayoutEffect(() => {
-    //alert("This triggered use effect");
-    fetch(link + "get-profile-picture", {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        username: localStorage.getItem("user")
-      }),
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        setProfilePicture(data['profile_picture'])
-      });
+    if (localStorage.getItem("user") !== null) {
+      fetch(link + "get-profile-picture", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: localStorage.getItem("user")
+        }),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          setProfilePicture(data['profile_picture'])
+        });
+    }
 
     if (userCookie == null) {
       setLoggedIn(false);


### PR DESCRIPTION
This PR fixes a crash caused by profile picture fetch.

* Because there wasn't a null check, the site was crashing on the login page. This was because there as no user info, so the server was trying to fetch a profile picture for a user that didn't exist