### PR TITLE
fix: Use dispatch event to trigger task list refresh on task add

### DIFF
--- a/front-end/src/components/TaskAdd.js
+++ b/front-end/src/components/TaskAdd.js
@@ -40,6 +40,8 @@ const TaskAdd = forwardRef((props, ref) => {
             })
                 .then((res) => {
                     res.json();
+                    // Dispatch event so we know to refresh the task list
+                    window.dispatchEvent(new Event("task_was_added"));
                 })
             console.log("Successfully added task!");
         } else {

--- a/front-end/src/components/TaskList.js
+++ b/front-end/src/components/TaskList.js
@@ -14,12 +14,25 @@ function TaskList({ username }) {
     const [taskDesc, setTaskDesc] = useState([]);
     const [tasksList, setTaskList] = useState([]);
     const [tasksDate, setTasksDate] = useState([]);
+    const [taskAdded, setTaskAdded] = useState([]);
 
     // Listen for current_tasks_day in localStorage
     window.addEventListener('current_tasks_day', () => {
         setTasksDate(localStorage.getItem("current_tasks_day"));
         console.log(localStorage.getItem("current_tasks_day"));
     });
+
+    // Listen for task_was_added
+    window.addEventListener('task_was_added', () => {
+        setTaskAdded(taskAdded => {
+            return [
+                ...taskAdded,
+                {
+                    taskAdded: "yes"
+                }
+            ]
+        })
+    })
 
     function getToday() {
         let date = new Date();
@@ -49,7 +62,7 @@ function TaskList({ username }) {
         })
             .then((res) => res.json())
             .then((data) => setTaskList(data));
-    }, [tasksDate, username]);
+    }, [taskAdded, tasksDate, username]);
 
     function MyVerticallyCenteredModal(props) {
         return (


### PR DESCRIPTION
fix: Use dispatch event to trigger task list refresh on task add

* Use a dispatch event to trigger a refresh of the task list when a task is added